### PR TITLE
Prediction Visualization: First Draft

### DIFF
--- a/R/mod_quiz_questionviz.R
+++ b/R/mod_quiz_questionviz.R
@@ -84,7 +84,8 @@ mod_quiz_questionviz_server <- function(id, stringAsFactors = FALSE, main_inputs
         choices = c(
           "",
           "Multiple Choice (single)",
-          "Multiple Choice (multiple)"
+          "Multiple Choice (multiple)",
+          "Prediction"
         ),
         selected = ""
       )
@@ -124,12 +125,16 @@ mod_quiz_questionviz_server <- function(id, stringAsFactors = FALSE, main_inputs
           question = input$quizviz_question,
           correct_answer = input$quizviz_correctanswer,
           arrange_by_frequency = input$quizviz_arrange_by_frequency
-
-
         ),
         "Multiple Choice (multiple)" = chart_multiplechoise_multiple(
           quiz_processed(),
           input$quizviz_question
+        ),
+        "Prediction" = chart_prediction(
+          quiz = quiz_processed(),
+          question = input$quizviz_question,
+          correct_answer = input$quizviz_correctanswer,
+          arrange_by_frequency = input$quizviz_arrange_by_frequency
         ),
       )
       }, error = function(e){

--- a/R/mod_quiz_questionviz_fct_graphs.R
+++ b/R/mod_quiz_questionviz_fct_graphs.R
@@ -59,3 +59,29 @@ chart_multiplechoise_multiple <- function(quiz, question) {
     hc_subtitle(text = "Grouped by 12 hours. The horizontal labels show the floor hour.") %>%
     hc_add_theme(hc_theme_smpl())
 }
+
+#' Histogram for prediction questions
+chart_prediction <- function(quiz, question,
+                                        correct_answer = NA,
+                                        arrange_by_frequency = TRUE) {
+
+  if (!is.na(correct_answer)) {
+    quiz %>%
+      pull(question) %>%
+      unlist() %>%
+      as.numeric() %>%
+      hchart() %>%
+      hc_xAxis(plotLines = list(
+                 list(color = "#FF5733",
+                      dashStyle = "Solid",
+                      width = 3,
+                      value = correct_answer, zIndex = 10)))
+  } else {
+    quiz %>%
+      pull(question) %>%
+      unlist() %>%
+      as.numeric() %>%
+      hchart()
+  }
+
+}

--- a/R/mod_quiz_questionviz_fct_uidynamic.R
+++ b/R/mod_quiz_questionviz_fct_uidynamic.R
@@ -26,7 +26,19 @@ get_quizviz_dynamic_ui <- function(quizviz_type, ns) {
         "Como estás?",
         choices = c("Bien", "Mal", "Mas o menos"),
         selected = c("Mal")
+      )
+    ),
+    "Prediction" = shiny::tagList(
+      shiny::selectInput(
+        ns("quizviz_question"),
+        "Question",
+        choices = c(""),
+        selected = NULL
       ),
+      shiny::textInput(
+        ns("quizviz_correctanswer"),
+        label = "Enter a reference point (if one exists)"
+      )
     )
   )
 }


### PR DESCRIPTION
Edits to `R/mod_quiz_questionviz*` scripts to add a new quiz type: *prediction questions* allow you to plot a histogram of student responses. There is an additional option to add a reference line if there is a "correct" answer to display.

<img width="1326" alt="Screen Shot 2023-02-15 at 12 23 05 PM" src="https://user-images.githubusercontent.com/4583367/219105488-8dd74bfc-c97f-44b7-b84d-0c913983b225.png">
